### PR TITLE
Update eal.c

### DIFF
--- a/lib/librte_eal/linux/eal/eal.c
+++ b/lib/librte_eal/linux/eal/eal.c
@@ -359,7 +359,23 @@ rte_eal_config_create(void)
 		RTE_LOG(ERR, EAL, "Cannot mmap memory for rte_config\n");
 		return -1;
 	}
-
+	
+	if ((RTE_PGSIZE_4K != getpagesize()) && (internal_config.base_virtaddr == 0)){
+		munmap(rte_mem_cfg_addr, sizeof(*rte_config.mem_config));
+		rte_mem_cfg_addr = RTE_PTR_ALIGN_CEIL((uintptr_t)rte_mem_cfg_addr, (size_t)RTE_PGSIZE_16M);
+		rte_mem_cfg_addr = RTE_ALIGN_FLOOR((uintptr_t)rte_mem_cfg_addr -
+                        sizeof(*rte_config.mem_config), sysconf(_SC_PAGE_SIZE));
+		rte_mem_cfg_addr = mmap(rte_mem_cfg_addr, sizeof(*rte_config.mem_config),
+                                PROT_READ | PROT_WRITE, MAP_SHARED, mem_cfg_fd, 0);
+		
+		if (rte_mem_cfg_addr == MAP_FAILED){
+			close(mem_cfg_fd);
+			mem_cfg_fd = -1;
+			RTE_LOG(ERR, EAL, "Cannot mmap memory for rte_config\n");
+			return -1;
+		}
+	}
+	
 	memcpy(rte_mem_cfg_addr, &early_mem_config, sizeof(early_mem_config));
 	rte_config.mem_config = rte_mem_cfg_addr;
 


### PR DESCRIPTION
This is a new method to avoid the  virtual address conflict between primary process and secondary process. This method can be successfully started with 64K pagesize. Avoid using the --base-virtaddr to configure the memory address after the start error. Can the code be written like this?